### PR TITLE
feat(ci): pin GitHub Actions by commit hash + 100% statement and branch coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,16 +5,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566  # v3
         with:
           python-version: "3.11"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
       - run: uv run make test-with-coverage
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/checkout_last_signed_commit.py
+++ b/checkout_last_signed_commit.py
@@ -262,7 +262,7 @@ def main(argv: list[str] | None = None) -> None:
     private_token = os.environ.get("PRIVATE_TOKEN")
     gitlab_key_fetcher = GitLabGPGKeyFetcher(private_token=private_token)
     gpg_instance = gnupg.GPG()
-    while signed_commit_sha is None:  # noqa: PLR1702 too-many-nested-blocks
+    while True:  # noqa: PLR1702 too-many-nested-blocks
         fetch_output = git_repo.fetch_git_repo(git_fetch_depth)
         regx_search = re.search(FETCH_NO_NEW_COMMITS_REGEX, fetch_output)
         if regx_search is not None and git_repo.fetch_depth == 2:

--- a/checkout_last_signed_commit.py
+++ b/checkout_last_signed_commit.py
@@ -289,9 +289,7 @@ def main(argv: list[str] | None = None) -> None:
                         if signed_commit_sha is not None:
                             logger.info("Got Signed Commit SHA: %s", signed_commit_sha)
                             git_repo.repo_instance.git.checkout(signed_commit_sha)
-                            unique_ids.clear()
-                            emails.clear()
-                            break
+                            return
         git_fetch_depth *= 2
 
 

--- a/tests/test_checkout_last_signed_commit.py
+++ b/tests/test_checkout_last_signed_commit.py
@@ -1,4 +1,5 @@
 # Copyright SUSE LLC
+import pathlib
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
@@ -154,6 +155,12 @@ class Tests(unittest.TestCase):
         )
         assert gpg_key == mock_gpg_key
 
+        """Test get_gpg_key_by_uid for empty response list with 200 status code"""
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        gpg_key = gpg_key_fetcher.get_gpg_key_by_uid(uid=500)
+        assert gpg_key is None
+
         """Test get_gpg_key_by_uid for empty response with error status as HTTP response"""
         mock_response.status_code = 404
         mock_response.raise_for_status = Mock()
@@ -192,17 +199,10 @@ class Tests(unittest.TestCase):
     @patch("checkout_last_signed_commit.Path")
     def test_init_or_load_repo(self, mock_path: MagicMock, mock_repo_class: MagicMock) -> None:
         # Case 1: .git does not exist, URL is provided -> Repo.init
-        def path_side_effect(path_str: str) -> MagicMock:
-            m = MagicMock()
-            if ".git" in str(path_str):
-                m.exists.return_value = False
-                m.is_dir.return_value = False
-            else:
-                m.exists.return_value = True
-                m.is_dir.return_value = True
-            return m
-
-        mock_path.side_effect = path_side_effect
+        mock_git_path = MagicMock()
+        mock_git_path.exists.return_value = False
+        mock_git_path.is_dir.return_value = False
+        mock_path.return_value = mock_git_path
 
         mock_repo = MagicMock()
         mock_repo_class.init.return_value = mock_repo
@@ -339,14 +339,14 @@ class Tests(unittest.TestCase):
                 "expected_exit": "No new commits found on server",
                 "expected_checkout": None,
             },
-            # Case 2: Success
+            # Case 2: Success with duplicate emails
             {
                 "fetch_repo_ret": "new commits",
-                "committer_emails": ["developer@suse.com"],
-                "uids": [123],
+                "committer_emails": ["skipped@suse.com", "skipped@suse.com", "dev@suse.com"],
+                "uids": [[123], [456]],
                 "gpg_key_side": "gpg-key-content",
                 "import_code": 0,
-                "signed_commit": "abcdef123456",
+                "signed_commit": [None, "abcdef123456"],
                 "expected_exit": None,
                 "expected_checkout": "abcdef123456",
             },
@@ -361,6 +361,17 @@ class Tests(unittest.TestCase):
                 "expected_exit": None,
                 "expected_checkout": "abcdef123456",
             },
+            # Case 4: Success with empty emails on first try, exits on second try
+            {
+                "fetch_repo_ret": "new commits",
+                "committer_emails": [[], ["dev@suse.com"]],
+                "uids": [789],
+                "gpg_key_side": "gpg-key-content-3",
+                "import_code": 0,
+                "signed_commit": "abcdef987654",
+                "expected_exit": None,
+                "expected_checkout": "abcdef987654",
+            },
         ]
 
         for s in scenarios:
@@ -371,12 +382,25 @@ class Tests(unittest.TestCase):
             mock_checker = MagicMock()
             mock_checker.fetch_depth = 2
             mock_checker.fetch_git_repo.return_value = s["fetch_repo_ret"]
-            mock_checker.get_commiter_email.return_value = s["committer_emails"]
-            mock_checker.get_signed_commit_sha.return_value = s["signed_commit"]
+
+            if s["committer_emails"] and isinstance(s["committer_emails"][0], list):
+                mock_checker.get_commiter_email.side_effect = s["committer_emails"]
+            else:
+                mock_checker.get_commiter_email.return_value = s["committer_emails"]
+
+            if isinstance(s["signed_commit"], list):
+                mock_checker.get_signed_commit_sha.side_effect = s["signed_commit"]
+            else:
+                mock_checker.get_signed_commit_sha.return_value = s["signed_commit"]
+
             mock_checker_class.return_value = mock_checker
 
             mock_fetcher = MagicMock()
-            mock_fetcher.fetch_user_uid.return_value = s["uids"]
+            if s["uids"] and isinstance(s["uids"][0], list):
+                mock_fetcher.fetch_user_uid.side_effect = s["uids"]
+            else:
+                mock_fetcher.fetch_user_uid.return_value = s["uids"]
+
             if isinstance(s["gpg_key_side"], list):
                 mock_fetcher.get_gpg_key_by_uid.side_effect = s["gpg_key_side"]
             else:
@@ -396,11 +420,18 @@ class Tests(unittest.TestCase):
                 assert exc_info.value.code == s["expected_exit"]
             else:
                 checkout_last_signed_commit.main(["-t", "fake_dir", "-u", "https://example.com/repo.git"])
-                if s["expected_checkout"]:
-                    mock_checker.repo_instance.git.checkout.assert_called_once_with(s["expected_checkout"])
-                else:
-                    mock_checker.repo_instance.git.checkout.assert_not_called()
+                mock_checker.repo_instance.git.checkout.assert_called_once_with(s["expected_checkout"])
 
+    def test_main_execution(self) -> None:
+        import sys
 
-if __name__ == "__main__":
-    unittest.main()
+        orig_argv = sys.argv
+        sys.argv = ["checkout_last_signed_commit.py"]
+
+        script_content = pathlib.Path("checkout_last_signed_commit.py").read_text(encoding="utf-8")
+        code = compile(script_content, "checkout_last_signed_commit.py", "exec")
+
+        with pytest.raises(SystemExit):
+            exec(code, {"__name__": "__main__"})  # noqa: S102
+
+        sys.argv = orig_argv

--- a/tests/test_checkout_last_signed_commit.py
+++ b/tests/test_checkout_last_signed_commit.py
@@ -174,6 +174,233 @@ class Tests(unittest.TestCase):
         )
         assert gpg_key is None
 
+    @patch("checkout_last_signed_commit.Path")
+    def test_create_checkout_dir(self, mock_path: MagicMock) -> None:
+        commit_checker = checkout_last_signed_commit.GitCheckVerifiedCommit(target_dir="fake_dir")
+
+        # Success case
+        assert commit_checker.create_checkout_dir() == "fake_dir"
+        mock_path.return_value.mkdir.assert_called_once_with(mode=0o766, parents=True, exist_ok=True)
+
+        # Exception case
+        mock_path.return_value.mkdir.side_effect = Exception("mkdir error")
+        res_err = commit_checker.create_checkout_dir()
+        assert isinstance(res_err, Exception)
+        assert str(res_err) == "mkdir error"
+
+    @patch("checkout_last_signed_commit.git.Repo")
+    @patch("checkout_last_signed_commit.Path")
+    def test_init_or_load_repo(self, mock_path: MagicMock, mock_repo_class: MagicMock) -> None:
+        # Case 1: .git does not exist, URL is provided -> Repo.init
+        def path_side_effect(path_str: str) -> MagicMock:
+            m = MagicMock()
+            if ".git" in str(path_str):
+                m.exists.return_value = False
+                m.is_dir.return_value = False
+            else:
+                m.exists.return_value = True
+                m.is_dir.return_value = True
+            return m
+
+        mock_path.side_effect = path_side_effect
+
+        mock_repo = MagicMock()
+        mock_repo_class.init.return_value = mock_repo
+
+        commit_checker = checkout_last_signed_commit.GitCheckVerifiedCommit(
+            target_dir="fake_dir", repo_url="https://github.com/example/repo.git"
+        )
+        commit_checker.init_or_load_repo()
+
+        mock_repo_class.init.assert_called_once_with("fake_dir", initial_branch="main")
+        mock_repo.create_remote.assert_called_once_with("origin", url="https://github.com/example/repo.git", tags=False)
+        mock_repo.config_writer.return_value.set_value.assert_called_once_with(
+            'gpg "ssh"', "allowedSignersFile", "/dev/null"
+        )
+        mock_repo.config_writer.return_value.set_value.return_value.release.assert_called_once()
+
+        # Case 2: .git exists -> git.Repo(path)
+        mock_repo_class.init.reset_mock()
+        mock_path.side_effect = None
+
+        mock_git_path = MagicMock()
+        mock_git_path.exists.return_value = True
+        mock_git_path.is_dir.return_value = True
+        mock_path.return_value = mock_git_path
+
+        commit_checker2 = checkout_last_signed_commit.GitCheckVerifiedCommit(
+            target_dir="fake_dir", repo_url="https://github.com/example/repo.git"
+        )
+        commit_checker2.init_or_load_repo()
+        mock_repo_class.assert_called_with("fake_dir/.git")
+
+    def test_fetch_git_repo(self) -> None:
+        commit_checker = checkout_last_signed_commit.GitCheckVerifiedCommit(target_dir="fake_dir")
+
+        # repo_instance is None
+        assert commit_checker.fetch_git_repo() is None
+
+        # repo_instance is not None
+        mock_repo = MagicMock()
+        mock_repo.git.fetch.return_value = ("status", "stdout", "stderr_output")
+        commit_checker.repo_instance = mock_repo
+
+        res = commit_checker.fetch_git_repo(depth_val=5)
+        assert res == "stderr_output"
+        assert commit_checker.fetch_depth == 5
+        mock_repo.git.fetch.assert_called_once_with("origin", depth=5, with_extended_output=True, progress=True)
+
+    def test_get_default_remote_branch(self) -> None:
+        commit_checker = checkout_last_signed_commit.GitCheckVerifiedCommit(target_dir="fake_dir")
+
+        # Case when repo_instance is None
+        assert commit_checker.get_default_remote_branch() is None
+
+        # Parameterized cases when repo_instance is not None
+        test_cases = [
+            ("  HEAD branch: main\n  Some other info", "main"),
+            ("No HEAD branch info", None),
+        ]
+        for remote_output, expected_branch in test_cases:
+            mock_repo = MagicMock()
+            mock_repo.git.remote.return_value = remote_output
+            commit_checker.repo_instance = mock_repo
+            assert commit_checker.get_default_remote_branch() == expected_branch
+            mock_repo.git.remote.assert_called_once_with("show", "origin")
+
+    @patch.object(checkout_last_signed_commit.GitCheckVerifiedCommit, "get_default_remote_branch")
+    def test_get_commiter_email(self, mock_get_def_branch: MagicMock) -> None:
+        commit_checker = checkout_last_signed_commit.GitCheckVerifiedCommit(target_dir="fake_dir")
+
+        # Case 1: branch is not None, repo_instance is None
+        assert commit_checker.get_commiter_email(git_branch="dev") == []
+
+        # Case 2: branch is None, repo_instance is not None
+        mock_get_def_branch.return_value = "main"
+        mock_repo = MagicMock()
+        mock_commit1 = MagicMock()
+        mock_commit1.committer.email = "user1@suse.com"
+        mock_commit2 = MagicMock()
+        mock_commit2.committer.email = "user2@suse.com"
+        mock_commit3 = MagicMock()
+        mock_commit3.committer.email = "user1@suse.com"
+        mock_repo.iter_commits.return_value = [mock_commit1, mock_commit2, mock_commit3]
+        commit_checker.repo_instance = mock_repo
+
+        emails = commit_checker.get_commiter_email(git_branch=None)
+        assert emails == ["user1@suse.com", "user2@suse.com"]
+        mock_get_def_branch.assert_called_once()
+        mock_repo.iter_commits.assert_called_once_with("origin/main", committer="suse")
+
+    def test_get_signed_commit_sha(self) -> None:
+        commit_checker = checkout_last_signed_commit.GitCheckVerifiedCommit(target_dir="fake_dir")
+
+        # Case when repo_instance is None
+        assert commit_checker.get_signed_commit_sha("main") is None
+
+        # Parameterized cases when repo_instance is not None
+        test_cases = [
+            ("main", "G abcdef1234567890\nN baddecaf", "abcdef1234567890"),
+            ("dev", "B somehash\nU fedcba0987654321", "fedcba0987654321"),
+            ("dev", "B somehash\nN otherhash", None),
+        ]
+        for branch, git_log, expected_sha in test_cases:
+            mock_repo = MagicMock()
+            mock_repo.git.log.return_value = git_log
+            commit_checker.repo_instance = mock_repo
+            assert commit_checker.get_signed_commit_sha(branch) == expected_sha
+            mock_repo.git.log.assert_called_once_with(f"origin/{branch}", '--pretty="%G? %H"')
+
+    def test_parse_args(self) -> None:
+        args = checkout_last_signed_commit.parse_args(["-t", "fake_dir", "-u", "https://example.com/repo.git"])
+        assert args.target_dir == "fake_dir"
+        assert args.url == "https://example.com/repo.git"
+
+    @patch("checkout_last_signed_commit.GitCheckVerifiedCommit")
+    @patch("checkout_last_signed_commit.GitLabGPGKeyFetcher")
+    @patch("checkout_last_signed_commit.gnupg.GPG")
+    def test_main_scenarios(
+        self,
+        mock_gpg_class: MagicMock,
+        mock_fetcher_class: MagicMock,
+        mock_checker_class: MagicMock,
+    ) -> None:
+        self.monkey_patch.setenv("PRIVATE_TOKEN", "fake_token")
+
+        scenarios = [
+            # Case 1: No new commits found
+            {
+                "fetch_repo_ret": "remote: Total 0 ",
+                "committer_emails": [],
+                "uids": [],
+                "gpg_key_side": None,
+                "import_code": 0,
+                "signed_commit": None,
+                "expected_exit": "No new commits found on server",
+                "expected_checkout": None,
+            },
+            # Case 2: Success
+            {
+                "fetch_repo_ret": "new commits",
+                "committer_emails": ["developer@suse.com"],
+                "uids": [123],
+                "gpg_key_side": "gpg-key-content",
+                "import_code": 0,
+                "signed_commit": "abcdef123456",
+                "expected_exit": None,
+                "expected_checkout": "abcdef123456",
+            },
+            # Case 3: Import failure and retry with second key/uid
+            {
+                "fetch_repo_ret": "new commits",
+                "committer_emails": ["developer@suse.com"],
+                "uids": [123, 456],
+                "gpg_key_side": [None, "good-gpg-key"],
+                "import_code": 1,
+                "signed_commit": "abcdef123456",
+                "expected_exit": None,
+                "expected_checkout": "abcdef123456",
+            },
+        ]
+
+        for s in scenarios:
+            mock_gpg_class.reset_mock()
+            mock_fetcher_class.reset_mock()
+            mock_checker_class.reset_mock()
+
+            mock_checker = MagicMock()
+            mock_checker.fetch_depth = 2
+            mock_checker.fetch_git_repo.return_value = s["fetch_repo_ret"]
+            mock_checker.get_commiter_email.return_value = s["committer_emails"]
+            mock_checker.get_signed_commit_sha.return_value = s["signed_commit"]
+            mock_checker_class.return_value = mock_checker
+
+            mock_fetcher = MagicMock()
+            mock_fetcher.fetch_user_uid.return_value = s["uids"]
+            if isinstance(s["gpg_key_side"], list):
+                mock_fetcher.get_gpg_key_by_uid.side_effect = s["gpg_key_side"]
+            else:
+                mock_fetcher.get_gpg_key_by_uid.return_value = s["gpg_key_side"]
+            mock_fetcher_class.return_value = mock_fetcher
+
+            mock_gpg = MagicMock()
+            mock_import_result = MagicMock()
+            mock_import_result.returncode = s["import_code"]
+            mock_import_result.stderr = "gpg: no valid OpenPGP data found" if s["import_code"] != 0 else ""
+            mock_gpg.import_keys.return_value = mock_import_result
+            mock_gpg_class.return_value = mock_gpg
+
+            if s["expected_exit"]:
+                with pytest.raises(SystemExit) as exc_info:
+                    checkout_last_signed_commit.main(["-t", "fake_dir", "-u", "https://example.com/repo.git"])
+                assert exc_info.value.code == s["expected_exit"]
+            else:
+                checkout_last_signed_commit.main(["-t", "fake_dir", "-u", "https://example.com/repo.git"])
+                if s["expected_checkout"]:
+                    mock_checker.repo_instance.git.checkout.assert_called_once_with(s["expected_checkout"])
+                else:
+                    mock_checker.repo_instance.git.checkout.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Motivation:
Ensure complete test coverage (100% statement and branch coverage) for the
checkout_last_signed_commit module on the new branch.

Design Choices:
Replaced the while-loop check with a direct infinite loop since loop exit is
solely handled by immediate returns. Added test scenarios covering empty
responses, duplicate committer emails, and empty email fetch lists. Utilized a
safe in-process compilation trick to cover the entry point execution block.

Benefits:
Achieves a robust, fully-tested verification utility with absolute 100%
statement and branch coverage, passing all style and type-checking checks.

Related issue: https://progress.opensuse.org/issues/203049

After:
* #14