### PR TITLE
fix: Add merge protection settings for automerging Pull Requests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -37,3 +37,7 @@ pull_request_rules:
     actions:
       merge:
         method: squash
+
+merge_protections_settings:
+  auto_merge_conditions: *base_checks
+  post_comment: false


### PR DESCRIPTION
This commit configures and enable merge protection setting to auto merge pull request based on the instructions mentioned in https://docs.mergify.com/merge-protections/auto-merge/